### PR TITLE
Time correction for friends online

### DIFF
--- a/classes/OhYesChat.php
+++ b/classes/OhYesChat.php
@@ -202,7 +202,7 @@ $friend['type'] = 'user';
 $friend['limit'] = false;
 
 $friend['joins'][] =  "join {$db_prefix}users_entity u on e.guid = u.guid";
-$friend['wheres'][] = "u.last_action > {$time} - 10";
+$friend['wheres'][] = "u.last_action > {$time} - 600";
 $friend['order_by'] = "u.last_action desc";
 
 $friends = elgg_get_entities_from_relationship($friend);	
@@ -225,7 +225,7 @@ public static function countOnline($entity){
 */
 public static function userStatus($user){
 $friend = get_user($user); 
-   if($friend->last_action > time() - 10){
+   if($friend->last_action > time() - 600){
 		 return 'online';  
 	  } 
 	  else {


### PR DESCRIPTION
Current time period to check if friend is online is 10 seconds on an action. Standard Elgg refreshes the action token every 10 minutes if browser is still active. So I propose to change this to the same period. Otherwise friends will not be shown unless they are very active.
